### PR TITLE
fix: properly resolve components dir name and warn about non existent dirs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,17 +45,25 @@ export default <Module> function () {
     await this.nuxt.callHook('components:dirs', options.dirs)
     const componentDirs = options.dirs.filter(isPureObjectOrString).map((dir) => {
       const dirOptions = typeof dir === 'object' ? dir : { path: dir }
-      const dirPath = getDir(this.nuxt.resolver.resolvePath(dirOptions.path))
+      let dirPath = dirOptions.path
+      try { dirPath = getDir(this.nuxt.resolver.resolvePath(dirOptions.path)) } catch (err) { }
       const transpile = typeof dirOptions.transpile === 'boolean' ? dirOptions.transpile : 'auto'
+
+      const enabled = fs.existsSync(dirPath)
+      if (!enabled && dirOptions.path !== '~/components') {
+        // eslint-disable-next-line no-console
+        console.warn('Components directory not found: `' + dirPath + '`')
+      }
 
       return {
         ...dirOptions,
+        enabled,
         path: dirPath,
         pattern: dirOptions.pattern || `**/*.{${builder.supportedExtensions.join(',')}}`,
         ignore: nuxtIgnorePatterns.concat(dirOptions.ignore || []),
         transpile: (transpile === 'auto' ? dirPath.includes('node_modules') : transpile)
       }
-    })
+    }).filter(d => d.enabled)
 
     this.options.build!.transpile!.push(...componentDirs.filter(dir => dir.transpile).map(dir => dir.path))
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs from 'fs'
 import chokidar from 'chokidar'
 import { Configuration as WebpackConfig, Entry as WebpackEntry } from 'webpack'
 // @ts-ignore
@@ -28,6 +29,7 @@ export interface Options {
 }
 
 const isPureObjectOrString = (val: any) => (!Array.isArray(val) && typeof val === 'object') || typeof val === 'string'
+const getDir = (p: string) => fs.statSync(p).isDirectory() ? p : path.dirname(p)
 
 export default <Module> function () {
   requireNuxtVersion.call(this, '2.10')
@@ -43,7 +45,7 @@ export default <Module> function () {
     await this.nuxt.callHook('components:dirs', options.dirs)
     const componentDirs = options.dirs.filter(isPureObjectOrString).map((dir) => {
       const dirOptions = typeof dir === 'object' ? dir : { path: dir }
-      const dirPath = this.nuxt.resolver.resolvePath(dirOptions.path)
+      const dirPath = getDir(this.nuxt.resolver.resolvePath(dirOptions.path))
       const transpile = typeof dirOptions.transpile === 'boolean' ? dirOptions.transpile : 'auto'
 
       return {

--- a/test/fixture/nuxt.config.ts
+++ b/test/fixture/nuxt.config.ts
@@ -12,6 +12,7 @@ const config: Configuration = {
   components: {
     dirs: [
       '~/components',
+      '~/non-existent',
       { path: '@/components/base', prefix: 'Base' },
       { path: '@/components/icons', prefix: 'Icon', transpile: true /* Only for coverage purpose */ }
     ]


### PR DESCRIPTION
- Having a components dir with `index.js` at root, breaks module
- Warn about not found dirs

closes #10