### PR TITLE
feat: advanced library integration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,16 @@ import { requireNuxtVersion } from './compatibility'
 import { scanComponents, ScanDir } from './scan'
 
 type componentsDirHook = (dirs: ComponentsDir[]) => void | Promise<void>
+type componentsExtendHook = (components: (ComponentsDir|ScanDir)[]) => void | Promise<void>
 
 declare module '@nuxt/types/config/hooks' {
   interface NuxtConfigurationHooks {
-    components?: { dirs?: componentsDirHook }
     'components:dirs'?: componentsDirHook
+    'components:extend'?: componentsExtendHook
+    components?: {
+      dirs?: componentsDirHook
+      extend?: componentsExtendHook
+    }
   }
 }
 
@@ -95,6 +100,9 @@ export default <Module> function () {
         }
 
         components = await scanComponents(componentDirs, this.options.srcDir!)
+
+        await this.nuxt.callHook('components:extend', components)
+
         await builder.generateRoutesAndFiles()
       })
 

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -77,8 +77,8 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
         _c = (await extendComponent(_c)) || _c
       }
 
-      const _import = `require('${_c.filePath}').${_c.export}`
-      const _asyncImport = `function () { return import('${_c.filePath}' /* webpackChunkName: "${_c.chunkName}" */).then(function(m) { return m['${_c.export}'] || m }) }`
+      const _import = _c.import || `require('${_c.filePath}').${_c.export}`
+      const _asyncImport = _c.asyncImport || `function () { return import('${_c.filePath}' /* webpackChunkName: "${_c.chunkName}" */).then(function(m) { return m['${_c.export}'] || m }) }`
 
       components.push({
         ..._c,

--- a/test/fixture/my-lib/components/MAwesome.js
+++ b/test/fixture/my-lib/components/MAwesome.js
@@ -1,0 +1,4 @@
+// @vue/component
+export const MAwesome = {
+  render: h => h('div', 'M is Awesome!')
+}

--- a/test/fixture/my-lib/components/index.js
+++ b/test/fixture/my-lib/components/index.js
@@ -1,0 +1,1 @@
+throw new Error('no export from index!')

--- a/test/fixture/nuxt.config.ts
+++ b/test/fixture/nuxt.config.ts
@@ -16,6 +16,15 @@ const config: Configuration = {
       { path: '@/components/base', prefix: 'Base' },
       { path: '@/components/icons', prefix: 'Icon', transpile: true /* Only for coverage purpose */ }
     ]
+  },
+
+  hooks: {
+    'components:dirs' (dirs) {
+      dirs.push({
+        path: path.resolve(__dirname, 'my-lib/components'),
+        extendComponent: _c => ({ ..._c, export: _c.pascalName })
+      })
+    }
   }
 }
 

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -4,5 +4,6 @@
     <LazyBar />
     <BaseButton />
     <IconHome />
+    <MAwesome />
   </div>
 </template>

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -31,7 +31,7 @@ describe('module', () => {
 
     /* eslint-disable no-console */
     const _warn = console.warn
-    console.warn = jest.fn
+    console.warn = jest.fn()
     await builder.build()
     expect(console.warn).toBeCalledTimes(1)
     expect(console.warn).toBeCalledWith('Components directory not found: `~/non-existent`')

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -28,7 +28,16 @@ describe('module', () => {
     builder = getBuilder(nuxt)
     hookFn = jest.fn()
     nuxt.hook('components:dirs', hookFn)
+
+    /* eslint-disable no-console */
+    const _warn = console.warn
+    console.warn = jest.fn
     await builder.build()
+    expect(console.warn).toBeCalledTimes(1)
+    expect(console.warn).toBeCalledWith('Components directory not found: `~/non-existent`')
+    console.warn = _warn
+    /* eslint-enable no-console */
+
     builder.generateRoutesAndFiles = jest.fn()
   })
 

--- a/test/unit/loader.test.ts
+++ b/test/unit/loader.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
 function expectToContainImports (content: string) {
   const fixturePath = p => path.resolve('test/fixture', p).replace(/\\/g, '\\\\')
   expect(content).toContain(`require('${fixturePath('components/Foo.vue')}')`)
-  expect(content).toContain(`function () { return import('${fixturePath('components/Bar.ts')}' /* webpackChunkName: "components${isWindows ? '_' : '/'}Bar" */) }`)
+  expect(content).toContain(`function () { return import('${fixturePath('components/Bar.ts')}' /* webpackChunkName: "components${isWindows ? '_' : '/'}Bar" */).then(function(m) { return m['default'] || m }) }`)
   expect(content).toContain(`require('${fixturePath('components/base/Button.vue')}')`)
   expect(content).toContain(`require('${fixturePath('components/icons/Home.vue')}')`)
 }

--- a/test/unit/tagExtractor.test.ts
+++ b/test/unit/tagExtractor.test.ts
@@ -4,8 +4,8 @@ import { extractTags } from '../../src/tagExtractor'
 test('with template', async () => {
   const tags = await extractTags(path.resolve('test/fixture/pages/index.vue'))
 
-  expect(tags).toHaveLength(5)
-  expect(tags).toEqual(['Foo', 'LazyBar', 'BaseButton', 'IconHome', 'div'])
+  expect(tags).toHaveLength(6)
+  expect(tags).toEqual(['Foo', 'LazyBar', 'BaseButton', 'IconHome', 'MAwesome', 'div'])
 })
 
 test('without template', async () => {


### PR DESCRIPTION
Addressing #9, #11

Component libraries, not always follow same conventions. This PR allows better integration with 3rd party libraries meanwhile keeping it as easy as possible.

## `dir.extendComponent(component)`

While preserving scanner convenience allows customizing scanned components. Extendable fields:

- filePath
- pascalName
- kebabName
- chunkName
- shortPath
- import (*)
- asyncImport (*)
- export

*: Can generate but the value is resolved after hook as it depends on `export` value

**Example:** A library using named exports per component: (BootstrapVue for instance)

```js
// Used in dirs or added by hook
{
 path: path.resolve(__dirname, 'my-lib/components'),
 extendComponent: _c => ({ ..._c, export: _c.pascalName })
}
```

## `components:extend`

This hook allows extending the final `components` result. Useful for additional post-proccessing and also register components with a different directory structure. Mostly useful for simple component libraries having one dist file with several exports (they should use `async: true` or will lose tree-shaking -- still added by usage for used page(s)) but can be also used for other unknown use-cases.