### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ components: {
       prefix: 'foo'
     }
   ]
-]
+}
 ```
 
 ## Setup


### PR DESCRIPTION
Prevent errors when copy/pasting