### PR TITLE
docs: make `components: true` requirement clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ## Usage
 
-Ensure using nuxt `2.13+` and `components` option is set in `nuxt.config`:
+Set the `components` option in `nuxt.config`:
 
 ```js
 export default {


### PR DESCRIPTION
Making it clear that regardless of nuxt version, the `components: true` option must be set.
Preventing: https://github.com/nuxt/components/issues/38