### PR TITLE
fix: disable loader for global dirs

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -11,7 +11,7 @@ export interface ScanDir {
   pattern?: string | string[]
   ignore?: string[]
   prefix?: string
-  global?: boolean,
+  global?: boolean | 'dev',
   extendComponent?: (component: Component) => Promise<Component | void> | (Component | void)
 }
 


### PR DESCRIPTION
Fulfill requirements of #18:

- Disable webpack dependency on dirs with `global: true`
- Completely disable webpack loader if all dirs are global
- Support `global: 'dev'` option


nuxt.config:

```js
export default {
  components: [ { path: '~/components', global: 'dev' } ]
}
```