### PR TITLE
feat: ignore storybook stories

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,11 @@ const componentsModule = <Module> function () {
         path: dirPath,
         extensions,
         pattern: dirOptions.pattern || `**/*.{${extensions.join(',')},}`,
-        ignore: nuxtIgnorePatterns.concat(dirOptions.ignore || []),
+        ignore: [
+          '**/*.stories.js', // ignore storybook files
+          ...nuxtIgnorePatterns,
+          ...(dirOptions.ignore || [])
+        ],
         transpile: (transpile === 'auto' ? dirPath.includes('node_modules') : transpile)
       }
     }).filter(d => d.enabled)


### PR DESCRIPTION
Add `*.stories.js` to ignore list.
Currently, the Component module detects Storybook files as components.  
See https://github.com/nuxt-community/storybook/issues/23