### PR TITLE
fix: try to fix slow watch

### DIFF
--- a/test/fixture/components/n/N1.vue
+++ b/test/fixture/components/n/N1.vue
@@ -1,0 +1,1 @@
+<template><span>1</span></template>

--- a/test/fixture/components/n/N10.vue
+++ b/test/fixture/components/n/N10.vue
@@ -1,0 +1,1 @@
+<template><span>10</span></template>

--- a/test/fixture/components/n/N100.vue
+++ b/test/fixture/components/n/N100.vue
@@ -1,0 +1,1 @@
+<template><span>100</span></template>

--- a/test/fixture/components/n/N101.vue
+++ b/test/fixture/components/n/N101.vue
@@ -1,0 +1,1 @@
+<template><span>101</span></template>

--- a/test/fixture/components/n/N102.vue
+++ b/test/fixture/components/n/N102.vue
@@ -1,0 +1,1 @@
+<template><span>102</span></template>

--- a/test/fixture/components/n/N103.vue
+++ b/test/fixture/components/n/N103.vue
@@ -1,0 +1,1 @@
+<template><span>103</span></template>

--- a/test/fixture/components/n/N104.vue
+++ b/test/fixture/components/n/N104.vue
@@ -1,0 +1,1 @@
+<template><span>104</span></template>

--- a/test/fixture/components/n/N105.vue
+++ b/test/fixture/components/n/N105.vue
@@ -1,0 +1,1 @@
+<template><span>105</span></template>

--- a/test/fixture/components/n/N106.vue
+++ b/test/fixture/components/n/N106.vue
@@ -1,0 +1,1 @@
+<template><span>106</span></template>

--- a/test/fixture/components/n/N107.vue
+++ b/test/fixture/components/n/N107.vue
@@ -1,0 +1,1 @@
+<template><span>107</span></template>

--- a/test/fixture/components/n/N108.vue
+++ b/test/fixture/components/n/N108.vue
@@ -1,0 +1,1 @@
+<template><span>108</span></template>

--- a/test/fixture/components/n/N109.vue
+++ b/test/fixture/components/n/N109.vue
@@ -1,0 +1,1 @@
+<template><span>109</span></template>

--- a/test/fixture/components/n/N11.vue
+++ b/test/fixture/components/n/N11.vue
@@ -1,0 +1,1 @@
+<template><span>11</span></template>

--- a/test/fixture/components/n/N110.vue
+++ b/test/fixture/components/n/N110.vue
@@ -1,0 +1,1 @@
+<template><span>110</span></template>

--- a/test/fixture/components/n/N111.vue
+++ b/test/fixture/components/n/N111.vue
@@ -1,0 +1,1 @@
+<template><span>111</span></template>

--- a/test/fixture/components/n/N112.vue
+++ b/test/fixture/components/n/N112.vue
@@ -1,0 +1,1 @@
+<template><span>112</span></template>

--- a/test/fixture/components/n/N113.vue
+++ b/test/fixture/components/n/N113.vue
@@ -1,0 +1,1 @@
+<template><span>113</span></template>

--- a/test/fixture/components/n/N114.vue
+++ b/test/fixture/components/n/N114.vue
@@ -1,0 +1,1 @@
+<template><span>114</span></template>

--- a/test/fixture/components/n/N115.vue
+++ b/test/fixture/components/n/N115.vue
@@ -1,0 +1,1 @@
+<template><span>115</span></template>

--- a/test/fixture/components/n/N116.vue
+++ b/test/fixture/components/n/N116.vue
@@ -1,0 +1,1 @@
+<template><span>116</span></template>

--- a/test/fixture/components/n/N117.vue
+++ b/test/fixture/components/n/N117.vue
@@ -1,0 +1,1 @@
+<template><span>117</span></template>

--- a/test/fixture/components/n/N118.vue
+++ b/test/fixture/components/n/N118.vue
@@ -1,0 +1,1 @@
+<template><span>118</span></template>

--- a/test/fixture/components/n/N119.vue
+++ b/test/fixture/components/n/N119.vue
@@ -1,0 +1,1 @@
+<template><span>119</span></template>

--- a/test/fixture/components/n/N12.vue
+++ b/test/fixture/components/n/N12.vue
@@ -1,0 +1,1 @@
+<template><span>12</span></template>

--- a/test/fixture/components/n/N120.vue
+++ b/test/fixture/components/n/N120.vue
@@ -1,0 +1,1 @@
+<template><span>120</span></template>

--- a/test/fixture/components/n/N121.vue
+++ b/test/fixture/components/n/N121.vue
@@ -1,0 +1,1 @@
+<template><span>121</span></template>

--- a/test/fixture/components/n/N122.vue
+++ b/test/fixture/components/n/N122.vue
@@ -1,0 +1,1 @@
+<template><span>122</span></template>

--- a/test/fixture/components/n/N123.vue
+++ b/test/fixture/components/n/N123.vue
@@ -1,0 +1,1 @@
+<template><span>123</span></template>

--- a/test/fixture/components/n/N124.vue
+++ b/test/fixture/components/n/N124.vue
@@ -1,0 +1,1 @@
+<template><span>124</span></template>

--- a/test/fixture/components/n/N125.vue
+++ b/test/fixture/components/n/N125.vue
@@ -1,0 +1,1 @@
+<template><span>125</span></template>

--- a/test/fixture/components/n/N126.vue
+++ b/test/fixture/components/n/N126.vue
@@ -1,0 +1,1 @@
+<template><span>126</span></template>

--- a/test/fixture/components/n/N127.vue
+++ b/test/fixture/components/n/N127.vue
@@ -1,0 +1,1 @@
+<template><span>127</span></template>

--- a/test/fixture/components/n/N128.vue
+++ b/test/fixture/components/n/N128.vue
@@ -1,0 +1,1 @@
+<template><span>128</span></template>

--- a/test/fixture/components/n/N129.vue
+++ b/test/fixture/components/n/N129.vue
@@ -1,0 +1,1 @@
+<template><span>129</span></template>

--- a/test/fixture/components/n/N13.vue
+++ b/test/fixture/components/n/N13.vue
@@ -1,0 +1,1 @@
+<template><span>13</span></template>

--- a/test/fixture/components/n/N130.vue
+++ b/test/fixture/components/n/N130.vue
@@ -1,0 +1,1 @@
+<template><span>130</span></template>

--- a/test/fixture/components/n/N131.vue
+++ b/test/fixture/components/n/N131.vue
@@ -1,0 +1,1 @@
+<template><span>131</span></template>

--- a/test/fixture/components/n/N132.vue
+++ b/test/fixture/components/n/N132.vue
@@ -1,0 +1,1 @@
+<template><span>132</span></template>

--- a/test/fixture/components/n/N133.vue
+++ b/test/fixture/components/n/N133.vue
@@ -1,0 +1,1 @@
+<template><span>133</span></template>

--- a/test/fixture/components/n/N134.vue
+++ b/test/fixture/components/n/N134.vue
@@ -1,0 +1,1 @@
+<template><span>134</span></template>

--- a/test/fixture/components/n/N135.vue
+++ b/test/fixture/components/n/N135.vue
@@ -1,0 +1,1 @@
+<template><span>135</span></template>

--- a/test/fixture/components/n/N136.vue
+++ b/test/fixture/components/n/N136.vue
@@ -1,0 +1,1 @@
+<template><span>136</span></template>

--- a/test/fixture/components/n/N137.vue
+++ b/test/fixture/components/n/N137.vue
@@ -1,0 +1,1 @@
+<template><span>137</span></template>

--- a/test/fixture/components/n/N138.vue
+++ b/test/fixture/components/n/N138.vue
@@ -1,0 +1,1 @@
+<template><span>138</span></template>

--- a/test/fixture/components/n/N139.vue
+++ b/test/fixture/components/n/N139.vue
@@ -1,0 +1,1 @@
+<template><span>139</span></template>

--- a/test/fixture/components/n/N14.vue
+++ b/test/fixture/components/n/N14.vue
@@ -1,0 +1,1 @@
+<template><span>14</span></template>

--- a/test/fixture/components/n/N140.vue
+++ b/test/fixture/components/n/N140.vue
@@ -1,0 +1,1 @@
+<template><span>140</span></template>

--- a/test/fixture/components/n/N141.vue
+++ b/test/fixture/components/n/N141.vue
@@ -1,0 +1,1 @@
+<template><span>141</span></template>

--- a/test/fixture/components/n/N142.vue
+++ b/test/fixture/components/n/N142.vue
@@ -1,0 +1,1 @@
+<template><span>142</span></template>

--- a/test/fixture/components/n/N143.vue
+++ b/test/fixture/components/n/N143.vue
@@ -1,0 +1,1 @@
+<template><span>143</span></template>

--- a/test/fixture/components/n/N144.vue
+++ b/test/fixture/components/n/N144.vue
@@ -1,0 +1,1 @@
+<template><span>144</span></template>

--- a/test/fixture/components/n/N145.vue
+++ b/test/fixture/components/n/N145.vue
@@ -1,0 +1,1 @@
+<template><span>145</span></template>

--- a/test/fixture/components/n/N146.vue
+++ b/test/fixture/components/n/N146.vue
@@ -1,0 +1,1 @@
+<template><span>146</span></template>

--- a/test/fixture/components/n/N147.vue
+++ b/test/fixture/components/n/N147.vue
@@ -1,0 +1,1 @@
+<template><span>147</span></template>

--- a/test/fixture/components/n/N148.vue
+++ b/test/fixture/components/n/N148.vue
@@ -1,0 +1,1 @@
+<template><span>148</span></template>

--- a/test/fixture/components/n/N149.vue
+++ b/test/fixture/components/n/N149.vue
@@ -1,0 +1,1 @@
+<template><span>149</span></template>

--- a/test/fixture/components/n/N15.vue
+++ b/test/fixture/components/n/N15.vue
@@ -1,0 +1,1 @@
+<template><span>15</span></template>

--- a/test/fixture/components/n/N150.vue
+++ b/test/fixture/components/n/N150.vue
@@ -1,0 +1,1 @@
+<template><span>150</span></template>

--- a/test/fixture/components/n/N151.vue
+++ b/test/fixture/components/n/N151.vue
@@ -1,0 +1,1 @@
+<template><span>151</span></template>

--- a/test/fixture/components/n/N152.vue
+++ b/test/fixture/components/n/N152.vue
@@ -1,0 +1,1 @@
+<template><span>152</span></template>

--- a/test/fixture/components/n/N153.vue
+++ b/test/fixture/components/n/N153.vue
@@ -1,0 +1,1 @@
+<template><span>153</span></template>

--- a/test/fixture/components/n/N154.vue
+++ b/test/fixture/components/n/N154.vue
@@ -1,0 +1,1 @@
+<template><span>154</span></template>

--- a/test/fixture/components/n/N155.vue
+++ b/test/fixture/components/n/N155.vue
@@ -1,0 +1,1 @@
+<template><span>155</span></template>

--- a/test/fixture/components/n/N156.vue
+++ b/test/fixture/components/n/N156.vue
@@ -1,0 +1,1 @@
+<template><span>156</span></template>

--- a/test/fixture/components/n/N157.vue
+++ b/test/fixture/components/n/N157.vue
@@ -1,0 +1,1 @@
+<template><span>157</span></template>

--- a/test/fixture/components/n/N158.vue
+++ b/test/fixture/components/n/N158.vue
@@ -1,0 +1,1 @@
+<template><span>158</span></template>

--- a/test/fixture/components/n/N159.vue
+++ b/test/fixture/components/n/N159.vue
@@ -1,0 +1,1 @@
+<template><span>159</span></template>

--- a/test/fixture/components/n/N16.vue
+++ b/test/fixture/components/n/N16.vue
@@ -1,0 +1,1 @@
+<template><span>16</span></template>

--- a/test/fixture/components/n/N160.vue
+++ b/test/fixture/components/n/N160.vue
@@ -1,0 +1,1 @@
+<template><span>160</span></template>

--- a/test/fixture/components/n/N161.vue
+++ b/test/fixture/components/n/N161.vue
@@ -1,0 +1,1 @@
+<template><span>161</span></template>

--- a/test/fixture/components/n/N162.vue
+++ b/test/fixture/components/n/N162.vue
@@ -1,0 +1,1 @@
+<template><span>162</span></template>

--- a/test/fixture/components/n/N163.vue
+++ b/test/fixture/components/n/N163.vue
@@ -1,0 +1,1 @@
+<template><span>163</span></template>

--- a/test/fixture/components/n/N164.vue
+++ b/test/fixture/components/n/N164.vue
@@ -1,0 +1,1 @@
+<template><span>164</span></template>

--- a/test/fixture/components/n/N165.vue
+++ b/test/fixture/components/n/N165.vue
@@ -1,0 +1,1 @@
+<template><span>165</span></template>

--- a/test/fixture/components/n/N166.vue
+++ b/test/fixture/components/n/N166.vue
@@ -1,0 +1,1 @@
+<template><span>166</span></template>

--- a/test/fixture/components/n/N167.vue
+++ b/test/fixture/components/n/N167.vue
@@ -1,0 +1,1 @@
+<template><span>167</span></template>

--- a/test/fixture/components/n/N168.vue
+++ b/test/fixture/components/n/N168.vue
@@ -1,0 +1,1 @@
+<template><span>168</span></template>

--- a/test/fixture/components/n/N169.vue
+++ b/test/fixture/components/n/N169.vue
@@ -1,0 +1,1 @@
+<template><span>169</span></template>

--- a/test/fixture/components/n/N17.vue
+++ b/test/fixture/components/n/N17.vue
@@ -1,0 +1,1 @@
+<template><span>17</span></template>

--- a/test/fixture/components/n/N170.vue
+++ b/test/fixture/components/n/N170.vue
@@ -1,0 +1,1 @@
+<template><span>170</span></template>

--- a/test/fixture/components/n/N171.vue
+++ b/test/fixture/components/n/N171.vue
@@ -1,0 +1,1 @@
+<template><span>171</span></template>

--- a/test/fixture/components/n/N172.vue
+++ b/test/fixture/components/n/N172.vue
@@ -1,0 +1,1 @@
+<template><span>172</span></template>

--- a/test/fixture/components/n/N173.vue
+++ b/test/fixture/components/n/N173.vue
@@ -1,0 +1,1 @@
+<template><span>173</span></template>

--- a/test/fixture/components/n/N174.vue
+++ b/test/fixture/components/n/N174.vue
@@ -1,0 +1,1 @@
+<template><span>174</span></template>

--- a/test/fixture/components/n/N175.vue
+++ b/test/fixture/components/n/N175.vue
@@ -1,0 +1,1 @@
+<template><span>175</span></template>

--- a/test/fixture/components/n/N176.vue
+++ b/test/fixture/components/n/N176.vue
@@ -1,0 +1,1 @@
+<template><span>176</span></template>

--- a/test/fixture/components/n/N177.vue
+++ b/test/fixture/components/n/N177.vue
@@ -1,0 +1,1 @@
+<template><span>177</span></template>

--- a/test/fixture/components/n/N178.vue
+++ b/test/fixture/components/n/N178.vue
@@ -1,0 +1,1 @@
+<template><span>178</span></template>

--- a/test/fixture/components/n/N179.vue
+++ b/test/fixture/components/n/N179.vue
@@ -1,0 +1,1 @@
+<template><span>179</span></template>

--- a/test/fixture/components/n/N18.vue
+++ b/test/fixture/components/n/N18.vue
@@ -1,0 +1,1 @@
+<template><span>18</span></template>

--- a/test/fixture/components/n/N180.vue
+++ b/test/fixture/components/n/N180.vue
@@ -1,0 +1,1 @@
+<template><span>180</span></template>

--- a/test/fixture/components/n/N181.vue
+++ b/test/fixture/components/n/N181.vue
@@ -1,0 +1,1 @@
+<template><span>181</span></template>

--- a/test/fixture/components/n/N182.vue
+++ b/test/fixture/components/n/N182.vue
@@ -1,0 +1,1 @@
+<template><span>182</span></template>

--- a/test/fixture/components/n/N183.vue
+++ b/test/fixture/components/n/N183.vue
@@ -1,0 +1,1 @@
+<template><span>183</span></template>

--- a/test/fixture/components/n/N184.vue
+++ b/test/fixture/components/n/N184.vue
@@ -1,0 +1,1 @@
+<template><span>184</span></template>

--- a/test/fixture/components/n/N185.vue
+++ b/test/fixture/components/n/N185.vue
@@ -1,0 +1,1 @@
+<template><span>185</span></template>

--- a/test/fixture/components/n/N186.vue
+++ b/test/fixture/components/n/N186.vue
@@ -1,0 +1,1 @@
+<template><span>186</span></template>

--- a/test/fixture/components/n/N187.vue
+++ b/test/fixture/components/n/N187.vue
@@ -1,0 +1,1 @@
+<template><span>187</span></template>

--- a/test/fixture/components/n/N188.vue
+++ b/test/fixture/components/n/N188.vue
@@ -1,0 +1,1 @@
+<template><span>188</span></template>

--- a/test/fixture/components/n/N189.vue
+++ b/test/fixture/components/n/N189.vue
@@ -1,0 +1,1 @@
+<template><span>189</span></template>

--- a/test/fixture/components/n/N19.vue
+++ b/test/fixture/components/n/N19.vue
@@ -1,0 +1,1 @@
+<template><span>19</span></template>

--- a/test/fixture/components/n/N190.vue
+++ b/test/fixture/components/n/N190.vue
@@ -1,0 +1,1 @@
+<template><span>190</span></template>

--- a/test/fixture/components/n/N191.vue
+++ b/test/fixture/components/n/N191.vue
@@ -1,0 +1,1 @@
+<template><span>191</span></template>

--- a/test/fixture/components/n/N192.vue
+++ b/test/fixture/components/n/N192.vue
@@ -1,0 +1,1 @@
+<template><span>192</span></template>

--- a/test/fixture/components/n/N193.vue
+++ b/test/fixture/components/n/N193.vue
@@ -1,0 +1,1 @@
+<template><span>193</span></template>

--- a/test/fixture/components/n/N194.vue
+++ b/test/fixture/components/n/N194.vue
@@ -1,0 +1,1 @@
+<template><span>194</span></template>

--- a/test/fixture/components/n/N195.vue
+++ b/test/fixture/components/n/N195.vue
@@ -1,0 +1,1 @@
+<template><span>195</span></template>

--- a/test/fixture/components/n/N196.vue
+++ b/test/fixture/components/n/N196.vue
@@ -1,0 +1,1 @@
+<template><span>196</span></template>

--- a/test/fixture/components/n/N197.vue
+++ b/test/fixture/components/n/N197.vue
@@ -1,0 +1,1 @@
+<template><span>197</span></template>

--- a/test/fixture/components/n/N198.vue
+++ b/test/fixture/components/n/N198.vue
@@ -1,0 +1,1 @@
+<template><span>198</span></template>

--- a/test/fixture/components/n/N199.vue
+++ b/test/fixture/components/n/N199.vue
@@ -1,0 +1,1 @@
+<template><span>199</span></template>

--- a/test/fixture/components/n/N2.vue
+++ b/test/fixture/components/n/N2.vue
@@ -1,0 +1,1 @@
+<template><span>2</span></template>

--- a/test/fixture/components/n/N20.vue
+++ b/test/fixture/components/n/N20.vue
@@ -1,0 +1,1 @@
+<template><span>20</span></template>

--- a/test/fixture/components/n/N200.vue
+++ b/test/fixture/components/n/N200.vue
@@ -1,0 +1,1 @@
+<template><span>200</span></template>

--- a/test/fixture/components/n/N21.vue
+++ b/test/fixture/components/n/N21.vue
@@ -1,0 +1,1 @@
+<template><span>21</span></template>

--- a/test/fixture/components/n/N22.vue
+++ b/test/fixture/components/n/N22.vue
@@ -1,0 +1,1 @@
+<template><span>22</span></template>

--- a/test/fixture/components/n/N23.vue
+++ b/test/fixture/components/n/N23.vue
@@ -1,0 +1,1 @@
+<template><span>23</span></template>

--- a/test/fixture/components/n/N24.vue
+++ b/test/fixture/components/n/N24.vue
@@ -1,0 +1,1 @@
+<template><span>24</span></template>

--- a/test/fixture/components/n/N25.vue
+++ b/test/fixture/components/n/N25.vue
@@ -1,0 +1,1 @@
+<template><span>25</span></template>

--- a/test/fixture/components/n/N26.vue
+++ b/test/fixture/components/n/N26.vue
@@ -1,0 +1,1 @@
+<template><span>26</span></template>

--- a/test/fixture/components/n/N27.vue
+++ b/test/fixture/components/n/N27.vue
@@ -1,0 +1,1 @@
+<template><span>27</span></template>

--- a/test/fixture/components/n/N28.vue
+++ b/test/fixture/components/n/N28.vue
@@ -1,0 +1,1 @@
+<template><span>28</span></template>

--- a/test/fixture/components/n/N29.vue
+++ b/test/fixture/components/n/N29.vue
@@ -1,0 +1,1 @@
+<template><span>29</span></template>

--- a/test/fixture/components/n/N3.vue
+++ b/test/fixture/components/n/N3.vue
@@ -1,0 +1,1 @@
+<template><span>3</span></template>

--- a/test/fixture/components/n/N30.vue
+++ b/test/fixture/components/n/N30.vue
@@ -1,0 +1,1 @@
+<template><span>30</span></template>

--- a/test/fixture/components/n/N31.vue
+++ b/test/fixture/components/n/N31.vue
@@ -1,0 +1,1 @@
+<template><span>31</span></template>

--- a/test/fixture/components/n/N32.vue
+++ b/test/fixture/components/n/N32.vue
@@ -1,0 +1,1 @@
+<template><span>32</span></template>

--- a/test/fixture/components/n/N33.vue
+++ b/test/fixture/components/n/N33.vue
@@ -1,0 +1,1 @@
+<template><span>33</span></template>

--- a/test/fixture/components/n/N34.vue
+++ b/test/fixture/components/n/N34.vue
@@ -1,0 +1,1 @@
+<template><span>34</span></template>

--- a/test/fixture/components/n/N35.vue
+++ b/test/fixture/components/n/N35.vue
@@ -1,0 +1,1 @@
+<template><span>35</span></template>

--- a/test/fixture/components/n/N36.vue
+++ b/test/fixture/components/n/N36.vue
@@ -1,0 +1,1 @@
+<template><span>36</span></template>

--- a/test/fixture/components/n/N37.vue
+++ b/test/fixture/components/n/N37.vue
@@ -1,0 +1,1 @@
+<template><span>37</span></template>

--- a/test/fixture/components/n/N38.vue
+++ b/test/fixture/components/n/N38.vue
@@ -1,0 +1,1 @@
+<template><span>38</span></template>

--- a/test/fixture/components/n/N39.vue
+++ b/test/fixture/components/n/N39.vue
@@ -1,0 +1,1 @@
+<template><span>39</span></template>

--- a/test/fixture/components/n/N4.vue
+++ b/test/fixture/components/n/N4.vue
@@ -1,0 +1,1 @@
+<template><span>4</span></template>

--- a/test/fixture/components/n/N40.vue
+++ b/test/fixture/components/n/N40.vue
@@ -1,0 +1,1 @@
+<template><span>40</span></template>

--- a/test/fixture/components/n/N41.vue
+++ b/test/fixture/components/n/N41.vue
@@ -1,0 +1,1 @@
+<template><span>41</span></template>

--- a/test/fixture/components/n/N42.vue
+++ b/test/fixture/components/n/N42.vue
@@ -1,0 +1,1 @@
+<template><span>42</span></template>

--- a/test/fixture/components/n/N43.vue
+++ b/test/fixture/components/n/N43.vue
@@ -1,0 +1,1 @@
+<template><span>43</span></template>

--- a/test/fixture/components/n/N44.vue
+++ b/test/fixture/components/n/N44.vue
@@ -1,0 +1,1 @@
+<template><span>44</span></template>

--- a/test/fixture/components/n/N45.vue
+++ b/test/fixture/components/n/N45.vue
@@ -1,0 +1,1 @@
+<template><span>45</span></template>

--- a/test/fixture/components/n/N46.vue
+++ b/test/fixture/components/n/N46.vue
@@ -1,0 +1,1 @@
+<template><span>46</span></template>

--- a/test/fixture/components/n/N47.vue
+++ b/test/fixture/components/n/N47.vue
@@ -1,0 +1,1 @@
+<template><span>47</span></template>

--- a/test/fixture/components/n/N48.vue
+++ b/test/fixture/components/n/N48.vue
@@ -1,0 +1,1 @@
+<template><span>48</span></template>

--- a/test/fixture/components/n/N49.vue
+++ b/test/fixture/components/n/N49.vue
@@ -1,0 +1,1 @@
+<template><span>49</span></template>

--- a/test/fixture/components/n/N5.vue
+++ b/test/fixture/components/n/N5.vue
@@ -1,0 +1,1 @@
+<template><span>5</span></template>

--- a/test/fixture/components/n/N50.vue
+++ b/test/fixture/components/n/N50.vue
@@ -1,0 +1,1 @@
+<template><span>50</span></template>

--- a/test/fixture/components/n/N51.vue
+++ b/test/fixture/components/n/N51.vue
@@ -1,0 +1,1 @@
+<template><span>51</span></template>

--- a/test/fixture/components/n/N52.vue
+++ b/test/fixture/components/n/N52.vue
@@ -1,0 +1,1 @@
+<template><span>52</span></template>

--- a/test/fixture/components/n/N53.vue
+++ b/test/fixture/components/n/N53.vue
@@ -1,0 +1,1 @@
+<template><span>53</span></template>

--- a/test/fixture/components/n/N54.vue
+++ b/test/fixture/components/n/N54.vue
@@ -1,0 +1,1 @@
+<template><span>54</span></template>

--- a/test/fixture/components/n/N55.vue
+++ b/test/fixture/components/n/N55.vue
@@ -1,0 +1,1 @@
+<template><span>55</span></template>

--- a/test/fixture/components/n/N56.vue
+++ b/test/fixture/components/n/N56.vue
@@ -1,0 +1,1 @@
+<template><span>56</span></template>

--- a/test/fixture/components/n/N57.vue
+++ b/test/fixture/components/n/N57.vue
@@ -1,0 +1,1 @@
+<template><span>57</span></template>

--- a/test/fixture/components/n/N58.vue
+++ b/test/fixture/components/n/N58.vue
@@ -1,0 +1,1 @@
+<template><span>58</span></template>

--- a/test/fixture/components/n/N59.vue
+++ b/test/fixture/components/n/N59.vue
@@ -1,0 +1,1 @@
+<template><span>59</span></template>

--- a/test/fixture/components/n/N6.vue
+++ b/test/fixture/components/n/N6.vue
@@ -1,0 +1,1 @@
+<template><span>6</span></template>

--- a/test/fixture/components/n/N60.vue
+++ b/test/fixture/components/n/N60.vue
@@ -1,0 +1,1 @@
+<template><span>60</span></template>

--- a/test/fixture/components/n/N61.vue
+++ b/test/fixture/components/n/N61.vue
@@ -1,0 +1,1 @@
+<template><span>61</span></template>

--- a/test/fixture/components/n/N62.vue
+++ b/test/fixture/components/n/N62.vue
@@ -1,0 +1,1 @@
+<template><span>62</span></template>

--- a/test/fixture/components/n/N63.vue
+++ b/test/fixture/components/n/N63.vue
@@ -1,0 +1,1 @@
+<template><span>63</span></template>

--- a/test/fixture/components/n/N64.vue
+++ b/test/fixture/components/n/N64.vue
@@ -1,0 +1,1 @@
+<template><span>64</span></template>

--- a/test/fixture/components/n/N65.vue
+++ b/test/fixture/components/n/N65.vue
@@ -1,0 +1,1 @@
+<template><span>65</span></template>

--- a/test/fixture/components/n/N66.vue
+++ b/test/fixture/components/n/N66.vue
@@ -1,0 +1,1 @@
+<template><span>66</span></template>

--- a/test/fixture/components/n/N67.vue
+++ b/test/fixture/components/n/N67.vue
@@ -1,0 +1,1 @@
+<template><span>67</span></template>

--- a/test/fixture/components/n/N68.vue
+++ b/test/fixture/components/n/N68.vue
@@ -1,0 +1,1 @@
+<template><span>68</span></template>

--- a/test/fixture/components/n/N69.vue
+++ b/test/fixture/components/n/N69.vue
@@ -1,0 +1,1 @@
+<template><span>69</span></template>

--- a/test/fixture/components/n/N7.vue
+++ b/test/fixture/components/n/N7.vue
@@ -1,0 +1,1 @@
+<template><span>7</span></template>

--- a/test/fixture/components/n/N70.vue
+++ b/test/fixture/components/n/N70.vue
@@ -1,0 +1,1 @@
+<template><span>70</span></template>

--- a/test/fixture/components/n/N71.vue
+++ b/test/fixture/components/n/N71.vue
@@ -1,0 +1,1 @@
+<template><span>71</span></template>

--- a/test/fixture/components/n/N72.vue
+++ b/test/fixture/components/n/N72.vue
@@ -1,0 +1,1 @@
+<template><span>72</span></template>

--- a/test/fixture/components/n/N73.vue
+++ b/test/fixture/components/n/N73.vue
@@ -1,0 +1,1 @@
+<template><span>73</span></template>

--- a/test/fixture/components/n/N74.vue
+++ b/test/fixture/components/n/N74.vue
@@ -1,0 +1,1 @@
+<template><span>74</span></template>

--- a/test/fixture/components/n/N75.vue
+++ b/test/fixture/components/n/N75.vue
@@ -1,0 +1,1 @@
+<template><span>75</span></template>

--- a/test/fixture/components/n/N76.vue
+++ b/test/fixture/components/n/N76.vue
@@ -1,0 +1,1 @@
+<template><span>76</span></template>

--- a/test/fixture/components/n/N77.vue
+++ b/test/fixture/components/n/N77.vue
@@ -1,0 +1,1 @@
+<template><span>77</span></template>

--- a/test/fixture/components/n/N78.vue
+++ b/test/fixture/components/n/N78.vue
@@ -1,0 +1,1 @@
+<template><span>78</span></template>

--- a/test/fixture/components/n/N79.vue
+++ b/test/fixture/components/n/N79.vue
@@ -1,0 +1,1 @@
+<template><span>79</span></template>

--- a/test/fixture/components/n/N8.vue
+++ b/test/fixture/components/n/N8.vue
@@ -1,0 +1,1 @@
+<template><span>8</span></template>

--- a/test/fixture/components/n/N80.vue
+++ b/test/fixture/components/n/N80.vue
@@ -1,0 +1,1 @@
+<template><span>80</span></template>

--- a/test/fixture/components/n/N81.vue
+++ b/test/fixture/components/n/N81.vue
@@ -1,0 +1,1 @@
+<template><span>81</span></template>

--- a/test/fixture/components/n/N82.vue
+++ b/test/fixture/components/n/N82.vue
@@ -1,0 +1,1 @@
+<template><span>82</span></template>

--- a/test/fixture/components/n/N83.vue
+++ b/test/fixture/components/n/N83.vue
@@ -1,0 +1,1 @@
+<template><span>83</span></template>

--- a/test/fixture/components/n/N84.vue
+++ b/test/fixture/components/n/N84.vue
@@ -1,0 +1,1 @@
+<template><span>84</span></template>

--- a/test/fixture/components/n/N85.vue
+++ b/test/fixture/components/n/N85.vue
@@ -1,0 +1,1 @@
+<template><span>85</span></template>

--- a/test/fixture/components/n/N86.vue
+++ b/test/fixture/components/n/N86.vue
@@ -1,0 +1,1 @@
+<template><span>86</span></template>

--- a/test/fixture/components/n/N87.vue
+++ b/test/fixture/components/n/N87.vue
@@ -1,0 +1,1 @@
+<template><span>87</span></template>

--- a/test/fixture/components/n/N88.vue
+++ b/test/fixture/components/n/N88.vue
@@ -1,0 +1,1 @@
+<template><span>88</span></template>

--- a/test/fixture/components/n/N89.vue
+++ b/test/fixture/components/n/N89.vue
@@ -1,0 +1,1 @@
+<template><span>89</span></template>

--- a/test/fixture/components/n/N9.vue
+++ b/test/fixture/components/n/N9.vue
@@ -1,0 +1,1 @@
+<template><span>9</span></template>

--- a/test/fixture/components/n/N90.vue
+++ b/test/fixture/components/n/N90.vue
@@ -1,0 +1,1 @@
+<template><span>90</span></template>

--- a/test/fixture/components/n/N91.vue
+++ b/test/fixture/components/n/N91.vue
@@ -1,0 +1,1 @@
+<template><span>91</span></template>

--- a/test/fixture/components/n/N92.vue
+++ b/test/fixture/components/n/N92.vue
@@ -1,0 +1,1 @@
+<template><span>92</span></template>

--- a/test/fixture/components/n/N93.vue
+++ b/test/fixture/components/n/N93.vue
@@ -1,0 +1,1 @@
+<template><span>93</span></template>

--- a/test/fixture/components/n/N94.vue
+++ b/test/fixture/components/n/N94.vue
@@ -1,0 +1,1 @@
+<template><span>94</span></template>

--- a/test/fixture/components/n/N95.vue
+++ b/test/fixture/components/n/N95.vue
@@ -1,0 +1,1 @@
+<template><span>95</span></template>

--- a/test/fixture/components/n/N96.vue
+++ b/test/fixture/components/n/N96.vue
@@ -1,0 +1,1 @@
+<template><span>96</span></template>

--- a/test/fixture/components/n/N97.vue
+++ b/test/fixture/components/n/N97.vue
@@ -1,0 +1,1 @@
+<template><span>97</span></template>

--- a/test/fixture/components/n/N98.vue
+++ b/test/fixture/components/n/N98.vue
@@ -1,0 +1,1 @@
+<template><span>98</span></template>

--- a/test/fixture/components/n/N99.vue
+++ b/test/fixture/components/n/N99.vue
@@ -1,0 +1,1 @@
+<template><span>99</span></template>

--- a/test/fixture/nuxt.config.ts
+++ b/test/fixture/nuxt.config.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import type { compilation } from 'webpack'
 import { NuxtConfig } from '@nuxt/types'
 import nuxtComponents from '../../src'
 
@@ -7,6 +8,18 @@ const config: NuxtConfig = {
     '@nuxt/typescript-build',
     nuxtComponents
   ],
+
+  build: {
+    plugins: [
+      {
+        apply (compiler) {
+          compiler.hooks.assetEmitted.tap('logEmit', (file: string) => {
+            console.log('Asset emitted:', file)
+          })
+        }
+      }
+    ]
+  },
 
   components: {
     dirs: [

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -7,5 +7,6 @@
     <IconHome />
     <MAwesome />
     <Functional />
+    <N1 />...<N100 />...<N200 />
   </div>
 </template>


### PR DESCRIPTION
**Background:** When we got slow build time reports (#18) a workaround was introduced in [v1.0.7](https://github.com/nuxt/components/releases/tag/v1.0.7) to support `global: 'dev'` option  (#70) but we kept as opt-in to avoid inconsistent behavior between dev/prod and it seems currently has issues with client-only. There is still no solid reprodution so first goal of this PR is to find reasons with a testable fixture.

## Slow filsystem watcher?

Even by using `global: 'dev'` we have reports of slow build time when components module is enabled. Either watcher itself can be slow or we somehow cause webpack rebuilds

## ~~Slow loader?~~

**Update:** Most be resolved by #126

Normally components loader operation should be quick but we make a webpack dependency when a component does not exists in a page to rebuild when file is crated which _might_ be the cause of slowness.



## Testing?

**Status: no reproduction yet**

Current fixture is updated with 200+ components `n/N{0...200}.vue` in order to make build slower but seems we need more complex setup....

### Trying locally

- Clone this repository
- yarn install
- yarn dev
