### PR TITLE
feat: components always available globally (hybrid loader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Nuxt by default does code-slitting per page and components. But sometimes we als
 - Component size is rather big (or has big dependencies imported) like a text-editor
 - Component is rendered conditionally with `v-if` or being in a modal
 
-In order to [lazy loaded](https://webpack.js.org/guides/lazy-loading/)) a componenet, all we need is adding `Lazy` prefix to component name.
+In order to [lazy load](https://webpack.js.org/guides/lazy-loading/)) a componenet, all we need is adding `Lazy` prefix to component name.
 
 You are now being able to easily import a component on-demand:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Codecov][codecov-src]][codecov-href]
 [![License][license-src]][license-href]
 
-> Module to scan and auto import components for Nuxt.js 2.13+
+> Module to scan and auto import components for Nuxt 2.13+
 
 - [🎲&nbsp; Play on CodeSandbox](https://githubbox.com/nuxt/components/tree/master/example)
 - [🎬&nbsp; Demonstration video (49s)](https://www.youtube.com/watch?v=lQ8OBrgVVr8)
@@ -28,12 +28,14 @@
 
 ## Features
 
-- Scan and auto import components
+- Automatically scan `components/` directory
+- No need to manually import components anymore
 - Multiple paths with customizable prefixes and lookup/ignore patterns
-- Dynamic import (**aka** Lazy loading) Support
-- Hot reloading Support
-- Transpiling Support (useful for component [library authors](#library-authors))
-- Fully tested!
+- Lazy loading (Async components)
+- Production code-splitting optimization (loader)
+- Hot reloading
+- Module integration ([library authors](#library-authors))
+- Fully tested
 
 ## Usage
 
@@ -68,70 +70,15 @@ No need anymore to manually import them in the `script` section!
 
 See [live demo](https://codesandbox.io/s/nuxt-components-cou9k) or [video example](https://www.youtube.com/watch?v=lQ8OBrgVVr8).
 
-## Dynamic Components
-
-In order to use [dynamic components](https://vuejs.org/v2/guide/components.html#Dynamic-Components) such as `<component :is="myComponent" />`, there are two options:
-- Using `components/global/` directory
-- Setting a custom path with the [global option](#global)
-
-### Using `components/global/`
-
-> This feature is only available in Nuxt `v2.14.8` or by upgrading this module to `v1.2.0`
-
-Any component inside `components/global/` will be available globally (with lazy import) so you can directly use them in your dynamic components.
-
-```bash
-| components/
----| global/
-------| Home.vue
-------| Post.vue
-```
-
-You can now use `<component>`:
-
-```html
-<component :is="'Home'" />
-<component :is="'Post'" />
-```
-
-### Using global option
-
-Considering this directory structure:
-
-```bash
-| components/
----| dynamic/
-------| Home.vue
-------| Post.vue
-```
-
-In our `nuxt.config` file, we add this path with `global: true` option:
-
-```js
-export default {
-  components: [
-    { path: '~/components/dynamic', global: true },
-    '~/components'
-  ]
-}
-```
-
-We can now use our dynamic components in our templates:
-
-```html
-<component :is="'Home'" />
-<component :is="'Post'" />
-```
-
-Please note that the `global` option does not mean components are added to main chunk but they are dynamically imported with webpack, [read more](#global).
-
 ### Lazy Imports
 
-To make a component imported dynamically ([lazy loaded](https://webpack.js.org/guides/lazy-loading/)), all you need is adding a `Lazy` prefix in your templates.
+Nuxt by default does code-slitting per page and components. But sometimes we also need to lazy load them:
+- Component size is rather big (or has big dependencies imported) like a text-editor
+- Component is rendered conditionally with `v-if` or being in a modal
 
-> If you think this prefix should be customizable, feel free to create a feature request issue!
+In order to [lazy loaded](https://webpack.js.org/guides/lazy-loading/)) a componenet, all we need is adding `Lazy` prefix to component name.
 
-You are now being able to easily import a component on-demand :
+You are now being able to easily import a component on-demand:
 
 ```html
 <template>
@@ -239,17 +186,6 @@ Each item can be either string or object. String is shortcut to `{ path }`.
 Path (absolute or relative) to the directory containing your components.
 
 You can use nuxt aliases (`~` or `@`) to refer to directories inside project or directly use a npm package path similar to require.
-
-#### global
-
-- Type: `Boolean`
-- Default: `false`
-
-Define if the components inside the path should be defined as global, this is useful when using [dynamic components](#dynamic-components).
-
-Please note that `global` option does not means components are added to main chunk but they are dynamically imported with webpack (see [here](https://github.com/nuxt/components/blob/master/templates/components/plugin.js))
-
-This option is disabled by default purposefully because forcing webpack to make one async chunk per-component makes chunking less efficient so you have to only use for dirs/when dynamic components are necessary.
 
 #### extensions
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ const componentsModule: Module<Options> = function () {
 
   const options: Options = {
     dirs: ['~/components'],
+    loader: !nuxt.options.dev,
     ...Array.isArray(components) ? { dirs: components } : components
   }
 
@@ -87,7 +88,9 @@ const componentsModule: Module<Options> = function () {
     await nuxt.callHook('components:extend', components)
 
     // Add loader for tree shaking in production only
-    if (nuxt.options.dev !== true) {
+    if (options.loader) {
+      // eslint-disable-next-line no-console
+      console.info('Using components loader to optimize imports')
       this.extendBuild((config) => {
         const vueRule = config.module?.rules.find(rule => rule.test?.toString().includes('.vue'))
         if (!vueRule) {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -27,15 +27,7 @@ export default async function loader (this: WebpackLoader.LoaderContext, content
   if (!this.resourceQuery) {
     this.addDependency(this.resourcePath)
 
-    const { dependencies, getComponents } = {
-      dependencies: [],
-      getComponents: () => [],
-      ...this.query
-    }
-
-    for (const dependency of dependencies) {
-      this.addDependency(dependency)
-    }
+    const { getComponents } = this.query
 
     const tags = await extractTags(this.resourcePath)
     const matchedComponents = matcher(tags, getComponents())

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface Component {
   shortPath: string
   async?: boolean
   chunkName: string
+  /** @deprecated */
   global: boolean
   level: number
 }
@@ -17,6 +18,7 @@ export interface ScanDir {
   pattern?: string | string[]
   ignore?: string[]
   prefix?: string
+  /** @deprecated */
   global?: boolean | 'dev'
   level?: number
   extendComponent?: (component: Component) => Promise<Component | void> | (Component | void)

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ type componentsExtendHook = (components: (ComponentsDir | ScanDir)[]) => void | 
 
 export interface Options {
   dirs: (string | ComponentsDir)[]
+  loader: Boolean
 }
 
 declare module '@nuxt/types/config/index' {

--- a/templates/components/plugin.js
+++ b/templates/components/plugin.js
@@ -1,13 +1,13 @@
 import Vue from 'vue'
-<% const globalComponents = options.getComponents().filter(c => c.global && c.async) %>
+<% const components = options.getComponents() %>
 
-const globalComponents = {
-<%= globalComponents.map(c => {
+const components = {
+<%= components.map(c => {
   const exp = c.export === 'default' ? `c.default || c` : `c['${c.export}']`
   return `  ${c.pascalName.replace(/^Lazy/, '')}: () => import('../${relativeToBuild(c.filePath)}' /* webpackChunkName: "${c.chunkName}" */).then(c => ${exp})`
 }).join(',\n') %>
 }
 
-for (const name in globalComponents) {
-  Vue.component(name, globalComponents[name])
+for (const name in components) {
+  Vue.component(name, components[name])
 }

--- a/test/fixture/components/functional/FunctionalChild.vue
+++ b/test/fixture/components/functional/FunctionalChild.vue
@@ -1,4 +1,4 @@
-<template functional>
+<template>
   <div>
     Functional Child
   </div>

--- a/test/fixture/pages/pug.vue
+++ b/test/fixture/pages/pug.vue
@@ -2,6 +2,7 @@
   div
     p pug loaded components:
     foo
+    bar
     lazy-bar
     base-button
     icon-home


### PR DESCRIPTION
With #43, we added support for `global: true` and introduced an  auto generated plugin that instead of loader strategy, globally registers components with async chunks. This option was disabled for 1-production to reduce network requests/size and allow webpack [smartly chunking](https://webpack.js.org/plugins/split-chunks-plugin/) per page and for 2-development to make behavior consistent with production and being aware if a component cannot work with loader.

It is proved that loader approach is not good for DX both for dev performance and limitations for detecting components. On the other hands without loader prod build is not optimized.

Approach of this PR is to globally register all components (async loaded) but when loader detects component usage per page, directly imports them (vue pick `components: {}` option over global one). This mixed approach brings best of two worlds.

Resolves #53,  resolves #92, resolves #91, resolves #88, resolves #68 and resolves #18 (loader)

**Slightly breaking change:** Components without `Lazy` prefix, are sync imports which might break some custom usages.

**Slightly breaking change:** Without loader, functional components cannot have functional children. This is probably more a Vue.js bug since functional components use `__ssrRender` of their parent's context and functional parent has no context
## TODO

- [x] Disable loader for development (customizable via `components.loader` to force enable or disable)
- [x] ~~Deprecate `global` option as we always do it~~ (silently deprecate to avoid side-effects)
- [x] Update tests
- [x] Update docs