### PR TITLE
fix(ignore): ignore typescript stories

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ const componentsModule: Module<Options> = function () {
         extensions,
         pattern: dirOptions.pattern || `**/*.{${extensions.join(',')},}`,
         ignore: [
-          '**/*.stories.js', // ignore storybook files
+          '**/*.stories.{js,ts,jsx,tsx}', // ignore storybook files
           ...nuxtIgnorePatterns,
           ...(dirOptions.ignore || [])
         ],


### PR DESCRIPTION
Improve stories ignore pattern to ignore `ts`, `tsx` and `jsx` files.  

Having these files in the project will lead to invalid js syntax error. (https://github.com/nuxt-community/storybook/issues/222#issuecomment-769788773)