### PR TITLE
feat: included pattern to ignore mixins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ const componentsModule: Module<Options> = function () {
         pattern: dirOptions.pattern || `**/*.{${extensions.join(',')},}`,
         ignore: [
           '**/*.stories.{js,ts,jsx,tsx}', // ignore storybook files
+          '**/*{m,M}ixin.{js,ts,jsx,tsx}', // ignore mixins
           ...nuxtIgnorePatterns,
           ...(dirOptions.ignore || [])
         ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ const componentsModule: Module<Options> = function () {
         pattern: dirOptions.pattern || `**/*.{${extensions.join(',')},}`,
         ignore: [
           '**/*.stories.{js,ts,jsx,tsx}', // ignore storybook files
-          '**/*{m,M}ixin.{js,ts,jsx,tsx}', // ignore mixins
+          '**/*{M,.m,-m}ixin.{js,ts,jsx,tsx}', // ignore mixins
           ...nuxtIgnorePatterns,
           ...(dirOptions.ignore || [])
         ],


### PR DESCRIPTION
As sugested in #108 I wasn't sure whether this is case-insensitive, so I assumed it isn't and added `{m,M}`. BTW, would it be possible to bump the Nuxt version? This package has some interesting bugfixes which I'd love to see as a dependency update included in Nuxt.

resolves #108