### PR TITLE
fix: allow components to be in multilevel nested folders

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -44,7 +44,7 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
 
       // Resolve componentName
       let componentName = pascalCase(basename(filePath, extname(filePath)).replace(/^\//g, ''))
-      const pathPrefix = pascalCase(relative(path, dirname(filePath)).replace(/^\//g, ''))
+      const pathPrefix = pascalCase(relative(path, dirname(filePath)).replace(/\//g, '-'))
       const parentDirName = pascalCase(basename(dirname(filePath)))
 
       if (['Index', parentDirName].includes(componentName)) {

--- a/test/fixture/components/global/Deep/Nested/MyComponent.vue
+++ b/test/fixture/components/global/Deep/Nested/MyComponent.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    MyComponent
+  </div>
+</template>

--- a/test/unit/scanner.test.ts
+++ b/test/unit/scanner.test.ts
@@ -19,7 +19,8 @@ test('scanner', async () => {
     'FormInputTextArea',
     'FormInputRadio',
     'FormLayout',
-    'Header'
+    'Header',
+    'DeepNestedMyComponent'
   ]
 
   expect(components.map(c => c.pascalName).sort()).toEqual([


### PR DESCRIPTION
If components were in multilevel nested folders the component name was invalid:

before:
`components/Deep/Nested/MyComponent` ->  `Deep/NestedMyComponent`

after:
`components/Deep/Nested/MyComponent` -> `DeepNestedMyComponent`