### PR TITLE
chore(dx): generate list of discovered components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,9 +167,9 @@ const componentsModule: Module<Options> = function () {
     }
 
     // Add CLI info to inspect discovered components
-    // eslint-disable-next-line no-console
     const componentsListFile = path.resolve(nuxt.options.buildDir, 'components/readme.md')
-    console.info('Auto discovered components:', path.relative(process.cwd(), componentsListFile))
+    // eslint-disable-next-line no-console
+    console.info('Discovered Components:', path.relative(process.cwd(), componentsListFile))
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,7 @@ const componentsModule: Module<Options> = function () {
     const templates = [
       'components/index.js',
       'components/plugin.js',
+      'components/readme.md',
       'vetur/tags.json'
     ]
     for (const t of templates) {
@@ -164,6 +165,11 @@ const componentsModule: Module<Options> = function () {
         options: { getComponents }
       })
     }
+
+    // Add CLI info to inspect discovered components
+    // eslint-disable-next-line no-console
+    const componentsListFile = path.resolve(nuxt.options.buildDir, 'components/readme.md')
+    console.info('Auto discovered components:', path.relative(process.cwd(), componentsListFile))
   })
 }
 

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -65,7 +65,7 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
 
       const pascalName = pascalCase(componentName)
       const kebabName = kebabCase(componentName)
-      const shortPath = filePath.replace(srcDir, '')
+      const shortPath = relative(srcDir, filePath)
       const chunkName = 'components/' + kebabName
 
       let _c = prefixComponent(prefix, {

--- a/templates/components/readme.md
+++ b/templates/components/readme.md
@@ -2,7 +2,7 @@
 
 This is an auto-generated list of components discovered by [nuxt/components](https://github.com/nuxt/components).
 
-You can directly use them by name without the need to import.
+You can directly use them in pages and other components without the need to import them.
 
 **Tip:** If a component is conditionally rendered with `v-if` and is big, it is better to use `Lazy` or `lazy-` prefix to lazy load.
 

--- a/templates/components/readme.md
+++ b/templates/components/readme.md
@@ -1,0 +1,16 @@
+# Auto Registred Components
+
+This is an auto generated list of components discovered by [nuxt/components](https://github.com/nuxt/components)
+
+You can directly use them by name without need to import.
+
+**Tip:** If component is conditionally rendered with `v-if` and is big, it is better to use `Lazy` or `lazy-` prefix to lazy load them.
+
+<%
+const components = options.getComponents()
+const list = components.map(c => {
+  const pascalName = c.pascalName.replace(/^Lazy/, '')
+  const kebabName = c.kebabName.replace(/^lazy-/, '')
+  return `- \`<${pascalName}>\` | \`<${kebabName}>\` (${c.shortPath})`
+})
+%><%= list.join('\n') %>

--- a/templates/components/readme.md
+++ b/templates/components/readme.md
@@ -1,10 +1,10 @@
-# Auto Registred Components
+# Discovered Components
 
-This is an auto generated list of components discovered by [nuxt/components](https://github.com/nuxt/components)
+This is an auto-generated list of components discovered by [nuxt/components](https://github.com/nuxt/components).
 
-You can directly use them by name without need to import.
+You can directly use them by name without the need to import.
 
-**Tip:** If component is conditionally rendered with `v-if` and is big, it is better to use `Lazy` or `lazy-` prefix to lazy load them.
+**Tip:** If a component is conditionally rendered with `v-if` and is big, it is better to use `Lazy` or `lazy-` prefix to lazy load.
 
 <%
 const components = options.getComponents()


### PR DESCRIPTION
Sometimes it is hard to inspect name of components are which auto-registered. This small change generates a readme file in `.nuxt` directory and console log to inform users about discovered components.

This is initial attempt to improve DX of discovered components. In next steps we shall use a web UI to provide catalog and playground for components.

Example CLI output:

```
ℹ Auto discovered components: .nuxt/components/readme.md 
```

Example md:
 
# Auto Registred Components

This is an auto generated list of components discovered by [nuxt/components](https://github.com/nuxt/components)

You can directly use them by name without need to import.

**Tip:** If component is conditionally rendered with `v-if` and is big, it is better to use `Lazy` or `lazy-` prefix to lazy load them.

- `<Big>` | `<big>` (components/global/Big.vue)
- `<Big>` | `<big>` (components/global/Big.vue)
- `<Mouse>` | `<mouse>` (components/global/Mouse.vue)
- `<Mouse>` | `<mouse>` (components/global/Mouse.vue)
- `<DeepNestedMyComponent>` | `<deep-nested-my-component>` (components/global/Deep/Nested/MyComponent.vue)
- `<DeepNestedMyComponent>` | `<deep-nested-my-component>` (components/global/Deep/Nested/MyComponent.vue)
- `<ComponentC>` | `<component-c>` (components/multifile/ComponentC/ComponentC.vue)
- `<ComponentC>` | `<component-c>` (components/multifile/ComponentC/ComponentC.vue)
- `<BaseButton>` | `<base-button>` (components/base/Button.vue)
- `<BaseButton>` | `<base-button>` (components/base/Button.vue)