### PR TITLE
fix(scan): avoid duplicate prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chokidar": "^3.5.1",
     "glob": "^7.1.6",
     "globby": "^11.0.2",
-    "scule": "^0.1.0",
+    "scule": "^0.1.1",
     "semver": "^7.3.4",
     "upath": "^2.0.1",
     "vue-template-compiler": "^2.6.12"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chokidar": "^3.5.1",
     "glob": "^7.1.6",
     "globby": "^11.0.2",
-    "lodash": "^4.17.20",
+    "scule": "^0.1.0",
     "semver": "^7.3.4",
     "upath": "^2.0.1",
     "vue-template-compiler": "^2.6.12"

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -40,7 +40,9 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
 
       const componentNameParts: string[] = []
 
-      while (prefixParts.length && kebabCase(prefixParts[0]) !== kebabCase(fileNameParts[0])) {
+      while (prefixParts.length &&
+        (prefixParts[0] || '').toLowerCase() !== (fileNameParts[0] || '').toLowerCase()
+      ) {
         componentNameParts.push(prefixParts.shift()!)
       }
 

--- a/test/fixture/components/ui/notification/NotificationWrapper.vue
+++ b/test/fixture/components/ui/notification/NotificationWrapper.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Notification Wrapper
+  </div>
+</template>

--- a/test/unit/scanner.test.ts
+++ b/test/unit/scanner.test.ts
@@ -20,7 +20,8 @@ test('scanner', async () => {
     'FormInputRadio',
     'FormLayout',
     'Header',
-    'DeepNestedMyComponent'
+    'DeepNestedMyComponent',
+    'UiNotificationWrapper'
   ]
 
   expect(components.map(c => c.pascalName).sort()).toEqual([

--- a/yarn.lock
+++ b/yarn.lock
@@ -10243,10 +10243,10 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-scule@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/scule/-/scule-0.1.0.tgz#e54d7489e9fd0e7a5cb2d0083aa14c2dde9268a6"
-  integrity sha512-I71+9bMGfiLM5J5I+qwmpHexgB/O7wi3bvWJ7y0H++QYMF7YlL/4HRA/pkH9S/+pGn44CE9EGg4L27KSsn26hQ==
+scule@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/scule/-/scule-0.1.1.tgz#6bf026f1815c646f061761f9bfd7a3e783f2d05c"
+  integrity sha512-1j2RlmUNADEprCkzDaeo8w2tdum/mvQWAKdRaS2raud7IOnPaDbLSFKhcY5xXPbAFYWk4ZQ0BUnfmg0ZUcI+Pg==
 
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10243,6 +10243,11 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+scule@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/scule/-/scule-0.1.0.tgz#e54d7489e9fd0e7a5cb2d0083aa14c2dde9268a6"
+  integrity sha512-I71+9bMGfiLM5J5I+qwmpHexgB/O7wi3bvWJ7y0H++QYMF7YlL/4HRA/pkH9S/+pGn44CE9EGg4L27KSsn26hQ==
+
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"


### PR DESCRIPTION
- Replace lodash / pascal utils with [nuxt-contrib/scule](https://github.com/nuxt-contrib/scule)
 - Handles mixed cases, different separators and case-aware splitting
- Change prefix checking algorithm to handle new case: `ui/Notification/NotificationWrapper` (*)

New duplicate removal algorthm:
- Create an empty array arr
- Do case aware splitting for both fileName and it's nested path (prefix)
- While first item of prefix is not same as first item of file name (case insensitive)
  - shift from prefix and push to arr
- Add rest of fileName parts
- Join arr and file name parts with PascalCase convention 

Example: `A-B/C/D/CDE.vue` => `<ABCDE>`

Also fixes nuxt/nuxt.js#8836