### PR TITLE
fix: improve scanner

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -26,11 +26,12 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
       filePaths.add(filePath)
 
       // Resolve componentName
-      const prefixParts = splitByCase(prefix ?? relative(path, dirname(filePath)))
+      const prefixParts = [
+        ...splitByCase(prefix || ''),
+        ...splitByCase(relative(path, dirname(filePath)))
+      ]
       const fileName = basename(filePath, extname(filePath))
-      const fileNameParts = fileName.toLowerCase() === 'index'
-        ? splitByCase(basename(dirname(filePath)))
-        : splitByCase(fileName)
+      const fileNameParts = fileName.toLowerCase() === 'index' ? [] : splitByCase(fileName)
 
       const componentNameParts: string[] = []
 

--- a/templates/components/index.js
+++ b/templates/components/index.js
@@ -1,9 +1,9 @@
-<%= options.getComponents().filter(c => !c.async).map(c => {
+<%= options.getComponents().map(c => {
   const exp = c.pascalName === c.export ? c.pascalName : `${c.export} as ${c.pascalName}`
   return `export { ${exp} } from '../${relativeToBuild(c.filePath)}'`
 }).join('\n') %>
 
-<%= options.getComponents().filter(c => c.async).map(c => {
+<%= options.getComponents().map(c => {
   const exp = c.export === 'default' ? `c.default || c` : `c['${c.export}']`
-  return `export const ${c.pascalName} = import('../${relativeToBuild(c.filePath)}' /* webpackChunkName: "${c.chunkName}" */).then(c => ${exp})`
+  return `export const Lazy${c.pascalName} = import('../${relativeToBuild(c.filePath)}' /* webpackChunkName: "${c.chunkName}" */).then(c => ${exp})`
 }).join('\n') %>

--- a/test/unit/loader.test.ts
+++ b/test/unit/loader.test.ts
@@ -29,7 +29,6 @@ beforeAll(async () => {
 function expectToContainImports (content: string) {
   const fixturePath = p => path.resolve('test/fixture', p).replace(/\\/g, '\\\\')
   expect(content).toContain(`require('${fixturePath('components/Foo.vue')}')`)
-  expect(content).toContain(`function () { return import('${fixturePath('components/Bar.js')}' /* webpackChunkName: "components/bar" */`)
   expect(content).toContain(`require('${fixturePath('components/base/Button.vue')}')`)
   expect(content).toContain(`require('${fixturePath('components/icons/Home.vue')}')`)
 }

--- a/test/unit/matcher.test.ts
+++ b/test/unit/matcher.test.ts
@@ -3,7 +3,7 @@ import { scanFixtureComponents } from './utils'
 
 test('matcher', async () => {
   const components = await scanFixtureComponents()
-  const tags = ['Foo', 'LazyBar', 'BaseButton', 'IconHome']
+  const tags = ['Foo', 'BaseButton', 'IconHome']
 
   const matchedComponents = matcher(tags, components).sort((a, b) => a.pascalName < b.pascalName ? -1 : 1)
 

--- a/test/unit/scanner.test.ts
+++ b/test/unit/scanner.test.ts
@@ -24,12 +24,9 @@ test('scanner', async () => {
     'UiNotificationWrapper'
   ]
 
-  expect(components.map(c => c.pascalName).sort()).toEqual([
-    ...expectedComponents,
-    ...expectedComponents.map(n => 'Lazy' + n)
-  ].sort())
+  expect(components.map(c => c.pascalName).sort()).toEqual(expectedComponents.sort())
 
   expect(warn).toBeCalledWith(
-    expect.stringMatching('Two component files resolving to the same name `SecondButton`')
+    expect.stringMatching('Two component files resolving to the same name `BaseSecondButton`')
   )
 })


### PR DESCRIPTION
- Remove generation of extra `Lazy` components (we register them globally and loader does not needs them)
- Split `prefix` dir option to avoid duplicate