### PR TITLE
fix: add stub default export

### DIFF
--- a/templates/components/plugin.js
+++ b/templates/components/plugin.js
@@ -12,3 +12,5 @@ for (const name in components) {
   Vue.component(name, components[name])
   Vue.component('Lazy' + name, components[name])
 }
+
+export default {}


### PR DESCRIPTION
allows it to be imported by `.nuxt/index.js` without throwing an error