### PR TITLE
fix: preserve non-common prefix parts

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -12,6 +12,10 @@ function hyphenate (str: string):string {
   return str.replace(/\B([A-Z])/g, '-$1').toLowerCase()
 }
 
+function compareCaseInsensitive (str1 = '', str2 = '') {
+  return str1.toLocaleLowerCase() === str2.toLocaleLowerCase()
+}
+
 export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<Component[]> {
   const components: Component[] = []
   const filePaths = new Set<string>()
@@ -38,15 +42,13 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
       const fileName = basename(filePath, extname(filePath))
       const fileNameParts = fileName.toLowerCase() === 'index' ? [] : splitByCase(fileName)
 
-      const componentNameParts: string[] = []
-
-      while (prefixParts.length &&
-        (prefixParts[0] || '').toLowerCase() !== (fileNameParts[0] || '').toLowerCase()
-      ) {
-        componentNameParts.push(prefixParts.shift()!)
+      for (const p of prefixParts) {
+        if (compareCaseInsensitive(p, fileNameParts[0])) {
+          fileNameParts.shift()
+        }
       }
 
-      const componentName = pascalCase(componentNameParts) + pascalCase(fileNameParts)
+      const componentName = pascalCase(prefixParts) + pascalCase(fileNameParts)
 
       if (resolvedNames.has(componentName)) {
         // eslint-disable-next-line no-console

--- a/test/fixture/components/my/form/MyFancyButton.vue
+++ b/test/fixture/components/my/form/MyFancyButton.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>MyFancyButton</div>
+</template>

--- a/test/unit/scanner.test.ts
+++ b/test/unit/scanner.test.ts
@@ -21,7 +21,8 @@ test('scanner', async () => {
     'FormLayout',
     'Header',
     'DeepNestedMyComponent',
-    'UiNotificationWrapper'
+    'UiNotificationWrapper',
+    'MyFancyButton'
   ]
 
   expect(components.map(c => c.pascalName).sort()).toEqual(expectedComponents.sort())

--- a/test/unit/scanner.test.ts
+++ b/test/unit/scanner.test.ts
@@ -18,11 +18,11 @@ test('scanner', async () => {
     'FormInputText',
     'FormInputTextArea',
     'FormInputRadio',
-    'FormLayout',
+    'FormLayoutsLayout',
     'Header',
     'DeepNestedMyComponent',
     'UiNotificationWrapper',
-    'MyFancyButton'
+    'MyFormFancyButton'
   ]
 
   expect(components.map(c => c.pascalName).sort()).toEqual(expectedComponents.sort())


### PR DESCRIPTION
related #175

Components module, prefixes component name by path until there is a mismatch. For better explanation I've added some examples:

id | path | current | after
-|-|-|-
1|`form/layouts/FormLayout.vue` | `FormLayout` | `FormLayoutsLayout`
2|`my/form/MyFancyButton.vue` | `MyFancyButton` | `MyFormFancyButton`
3|`field/number/integer/FieldNumberOfServings.vue` | `NumberIntegerFieldNumberOfServings` | `FieldNumberIntegerOfServings`
4|`ui/notification/NotificationWrapper.vue` | `UINotificationWrapper` | `UINotificationWrapper`


Cases 1-3 are basically bad usages since prefix used in filename does not matches path. Current behavior is fixing this mismatch by **respecting file name** and new change is fixing mismatch by **respecting full path**

