### PR TITLE
fix: use consola so that this.options.build.quiet is taken into account

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/loader-utils": "latest",
     "@types/lodash": "latest",
     "@types/semver": "latest",
+    "consola": "^2.15.3",
     "eslint": "latest",
     "jest": "latest",
     "loader-utils": "latest",
@@ -55,5 +56,8 @@
     "pug-plain-loader": "latest",
     "siroc": "latest",
     "standard-version": "latest"
+  },
+  "peerDependencies": {
+    "consola": "^2.15.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from 'upath'
 import chokidar from 'chokidar'
 import type { Configuration as WebpackConfig, Entry as WebpackEntry } from 'webpack'
 import type { Module } from '@nuxt/types/config'
+import consola from 'consola'
 
 import { requireNuxtVersion } from './compatibility'
 import { scanComponents } from './scan'
@@ -93,7 +94,7 @@ const componentsModule: Module<Options> = function () {
     // Add loader for tree shaking in production only
     if (options.loader) {
       // eslint-disable-next-line no-console
-      console.info('Using components loader to optimize imports')
+      consola.info('Using components loader to optimize imports')
       this.extendBuild((config) => {
         const vueRule = config.module?.rules.find(rule => rule.test?.toString().includes('.vue'))
         if (!vueRule) {
@@ -172,7 +173,7 @@ const componentsModule: Module<Options> = function () {
     // Add CLI info to inspect discovered components
     const componentsListFile = path.resolve(nuxt.options.buildDir, 'components/readme.md')
     // eslint-disable-next-line no-console
-    console.info('Discovered Components:', path.relative(process.cwd(), componentsListFile))
+    consola.info('Discovered Components:', path.relative(process.cwd(), componentsListFile))
   })
 }
 


### PR DESCRIPTION
Nuxt has the `this.options.build.quiet` variable to decide if console output should happen. It sets `consola.level` depending on this variable.

`@nuxt/components` should also use `consola` so that the output is muted correctly. Currently, `@nuxt/components` still outputs to the console if Nuxt is built via the API.

I added `consola` as a peer dependency so that it does not install its own version.

It's actually a bit hard to test this because `@nuxt/components` is directly integrated into Nuxt.