### PR TITLE
fix: when using Node 16 will report an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "exports": {
     ".": "./dist/index.js",
-    "./": "./",
+    "./*": "./*",
     "./loader": "./dist/loader.js"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
With Node 16, we will get the following error when run a project.

This is because of [DEP0148](https://nodejs.org/api/deprecations.html#DEP0148).

```
 ERROR  (node:61954) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at /Users/jannchie/code/blog/node_modules/@nuxt/components/package.json.
Update this package.json to use a subpath pattern like "./*".
    at emitFolderMapDeprecation (node:internal/modules/esm/resolve:69:11)
    at packageExportsResolve (node:internal/modules/esm/resolve:542:7)
    at resolveExports (node:internal/modules/cjs/loader:477:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:517:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:926:27)
    at Function.resolve (node:internal/modules/cjs/helpers:99:19)
    at resolveModule (/Users/jannchie/code/blog/node_modules/@nuxt/utils/dist/utils.js:818:19)
    at requireModule (/Users/jannchie/code/blog/node_modules/@nuxt/utils/dist/utils.js:824:19)
    at tryRequire (/Users/jannchie/code/blog/node_modules/@nuxt/utils/dist/utils.js:828:16)
    at Object.getPKG (/Users/jannchie/code/blog/node_modules/@nuxt/utils/dist/utils.js:836:10)
```