### PR TITLE
Fix deprecated folder mapping: (node:5173) [DEP0148]

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "exports": {
     ".": "./dist/index.js",
-    "./": "./",
+    "./*": "./*",
     "./loader": "./dist/loader.js"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
(node:5173) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at /node_modules/@nuxt/components/package.json.

Update this package.json to use a subpath pattern like "./*".

(Use `node --trace-deprecation ...` to show where the warning was created)

node version: 16.0.0