### PR TITLE
feat: support webpack magic comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ export default {
 </script>
 ```
 
+If you want to prefetch or preload the components with `Lazy` prefix, you can configure it by [prefetch/preload options](#prefetch/preload).
+
 ### Nested Components
 
 If you have components in nested directories:
@@ -309,7 +311,7 @@ Components having the same name in `~/components` will overwrite the one in `my-
 - Type: `Boolean/Number`
 - Default: `false`
 
-These properties are used for Wepack's magic comments, learn more in [Wepack's official documentation](https://webpack.js.org/api/module-methods/#magic-comments).
+These properties are used in production to configure how [components with `Lazy` prefix](#Lazy-Imports) are handled by Wepack via its magic comments, learn more in [Wepack's official documentation](https://webpack.js.org/api/module-methods/#magic-comments).
 
 ```js
 export default {

--- a/README.md
+++ b/README.md
@@ -304,6 +304,31 @@ export default {
 
 Components having the same name in `~/components` will overwrite the one in `my-theme/components`, learn more in [Overwriting Components](#overwriting-components). The lowest value will overwrite.
 
+#### prefetch/preload
+
+- Type: `Boolean/Number`
+- Default: `false`
+
+These properties are used for Wepack's magic comments, learn more in [Wepack's official documentation](https://webpack.js.org/api/module-methods/#magic-comments).
+
+```js
+export default {
+  components: [
+   { path: 'my-theme/components', prefetch: true }
+  ]
+}
+```
+
+yields:
+
+```js
+// plugin.js
+const componets = {
+  MyComponentA: import(/* webpackPrefetch: true */ ...),
+  MyComponentB: import(/* webpackPrefetch: true */ ...)
+}
+```
+
 ## Migration guide
 
 ## `v1` to `v2`

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -17,7 +17,7 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
   const filePaths = new Set<string>()
   const scannedPaths: string[] = []
 
-  for (const { path, pattern, ignore = [], prefix, extendComponent, pathPrefix, level } of dirs.sort(sortDirsByPathLength)) {
+  for (const { path, pattern, ignore = [], prefix, extendComponent, pathPrefix, level, prefetch = false, preload = false } of dirs.sort(sortDirsByPathLength)) {
     const resolvedNames = new Map<string, string>()
 
     for (const _file of await globby(pattern!, { cwd: path, ignore })) {
@@ -76,7 +76,9 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
         asyncImport: '',
         export: 'default',
         global: Boolean(global),
-        level: Number(level)
+        level: Number(level),
+        prefetch: Boolean(prefetch),
+        preload: Boolean(preload)
       }
 
       if (typeof extendComponent === 'function') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface Component {
   /** @deprecated */
   global: boolean
   level: number
+  prefetch: boolean
+  preload: boolean
 }
 
 export interface ScanDir {
@@ -22,6 +24,8 @@ export interface ScanDir {
   global?: boolean | 'dev'
   pathPrefix?: boolean
   level?: number
+  prefetch: boolean
+  preload: boolean
   extendComponent?: (component: Component) => Promise<Component | void> | (Component | void)
 }
 

--- a/templates/components/plugin.js
+++ b/templates/components/plugin.js
@@ -9,7 +9,7 @@ const components = {
   const magicComments = [
     `webpackChunkName: "${c.chunkName}"`,
     c.prefetch === true || typeof c.prefetch === 'number' ? `webpackPrefetch: ${c.prefetch}` : false,
-    c.preload === true || typeof c.preload === 'number' ? `webpackPreload: ${c.prefetch}` : false,
+    c.preload === true || typeof c.preload === 'number' ? `webpackPreload: ${c.preload}` : false,
   ].filter(Boolean).join(', ')
 
   return `  ${c.pascalName.replace(/^Lazy/, '')}: () => import('../${relativeToBuild(c.filePath)}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`

--- a/templates/components/plugin.js
+++ b/templates/components/plugin.js
@@ -8,8 +8,8 @@ const components = {
   const exp = c.export === 'default' ? `c.default || c` : `c['${c.export}']`
   const magicComments = [
     `webpackChunkName: "${c.chunkName}"`,
-    c.prefetch ? `webpackPrefetch: ${c.prefetch ? 'true' : 'false'}` : false,
-    c.preload ? `webpackPreload: ${c.preload ? 'true' : 'false'}` : false,
+    c.prefetch === true || typeof c.prefetch === 'number' ? `webpackPrefetch: ${c.prefetch}` : false,
+    c.preload === true || typeof c.preload === 'number' ? `webpackPreload: ${c.prefetch}` : false,
   ].filter(Boolean).join(', ')
 
   return `  ${c.pascalName.replace(/^Lazy/, '')}: () => import('../${relativeToBuild(c.filePath)}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`

--- a/templates/components/plugin.js
+++ b/templates/components/plugin.js
@@ -6,7 +6,13 @@ import { wrapFunctional } from './utils'
 const components = {
 <%= components.map(c => {
   const exp = c.export === 'default' ? `c.default || c` : `c['${c.export}']`
-  return `  ${c.pascalName.replace(/^Lazy/, '')}: () => import('../${relativeToBuild(c.filePath)}' /* webpackChunkName: "${c.chunkName}" */).then(c => wrapFunctional(${exp}))`
+  const magicComments = [
+    `webpackChunkName: "${c.chunkName}"`,
+    c.prefetch ? `webpackPrefetch: ${c.prefetch ? 'true' : 'false'}` : false,
+    c.preload ? `webpackPreload: ${c.preload ? 'true' : 'false'}` : false,
+  ].filter(Boolean).join(', ')
+
+  return `  ${c.pascalName.replace(/^Lazy/, '')}: () => import('../${relativeToBuild(c.filePath)}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`
 }).join(',\n') %>
 }
 


### PR DESCRIPTION
This PR is to support #71 in some way.

I just read through the code of this module once, so I may not be misunderstanding the implementation and making mistakes in approach. But, still, I will submit this PR with _WIP_ in the title, so that everyone can point them out and/or have a discussion on my implementation.

---

According to [Webpack's documentation](https://webpack.js.org/api/module-methods/#magic-comments), there are 6 kinds of magic comments supported by Webpack 4+, and they can be combined. 

- `webpackInclude`
- `webpackExclude`
- `webpackChunkName`
- `webpackMode`
- `webpackPrefetch`
- `webpackPreload`

In the context of component importing, I think it would be enough to support only `preferch` and `preload` (at least to resolve #71).

---

The author of the issue wants to set magic comment per component in the place where it's used.

```html
<LazyHeader /* webpackPreload: true */ />
```

However, it will be hassle to detect them in build pipeline. 
In addition, I guess it is likely that lazy components are wanted to be prefetched or preloaded, regardless of the places they are used.
So, IMO, it will be reasonable to configure it before components are handled by the loader (or before they are imported).

---

My approach is to add 2 properties to objects of `components` array module option: `prefetch` and `preload`.
This would be simplest in terms of code and API change. In this way, all the components under specific directories are configured same.

2nd possible approach will be to provide a way to configure magic comments per component. 
In this approach, API would get to be a little bit complicated.

3rd approach will be to statically add magic comments in `import` statement in the loader.
I know "no option" is best design sometimes, but I'm not sure it's now.

I do appreciate any feedback.

---

P.S.

This is my very first PR to Nuxt Component modules, after Nuxt Content. 👶 
I hope that my PR will be consequently merged and used by Nuxt Core.

---

TODO

- [x] Verify approach
- [x] Take review and fix code
- [ ] Add tests
- [x] Update documentation