### PR TITLE
fix(template): prevent error when a folder in components start with a…

### DIFF
--- a/templates/components/plugin.js
+++ b/templates/components/plugin.js
@@ -12,7 +12,7 @@ const components = {
     c.preload === true || typeof c.preload === 'number' ? `webpackPreload: ${c.preload}` : false,
   ].filter(Boolean).join(', ')
 
-  return `  ${c.pascalName.replace(/^Lazy/, '')}: () => import('../${relativeToBuild(c.filePath)}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`
+  return `  '${c.pascalName.replace(/^Lazy/, '')}': () => import('../${relativeToBuild(c.filePath)}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`
 }).join(',\n') %>
 }
 


### PR DESCRIPTION
When you use a file architecture that includes a folder with a number like that :
![image](https://user-images.githubusercontent.com/7237157/128496960-98a472e6-82cf-43a0-ad2e-31c36aba5d59.png)

The compiler break due to an invalid js object:
![image](https://user-images.githubusercontent.com/7237157/128497067-62bf9926-5d8a-4a5e-b712-9269271b8fee.png)

I suggest wrapping object keys in quotes to prevent that.