### PR TITLE
feat: remove numeric prefix from component names

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -51,7 +51,10 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
         componentNameParts.push(prefixParts.shift()!)
       }
 
-      const componentName = pascalCase(componentNameParts) + pascalCase(fileNameParts)
+      let componentName = pascalCase(componentNameParts) + pascalCase(fileNameParts)
+
+      // Remove number suffixes
+      componentName = componentName.replace(/^\d+/, '')
 
       if (resolvedNames.has(componentName)) {
         // eslint-disable-next-line no-console

--- a/test/fixture/components/0-base/Button.vue
+++ b/test/fixture/components/0-base/Button.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Base Button 2!
+  </div>
+</template>

--- a/test/fixture/components/0-base/SecondButton/SecondButton.vue
+++ b/test/fixture/components/0-base/SecondButton/SecondButton.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Second Button
+  </div>
+</template>

--- a/test/fixture/components/0-base/SecondButton/index.vue
+++ b/test/fixture/components/0-base/SecondButton/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Second Button (index)
+  </div>
+</template>


### PR DESCRIPTION
- History: #218, https://github.com/nuxt/components/pull/218#issuecomment-896249659

This feature allows adding prefixes to the directory or component names for easier sorting in the filesystem (`base` => `2-base`). Until now such prefix was causing an error, it is a non-breaking change.

Point by @AMoreaux (https://github.com/nuxt/components/pull/218#issuecomment-896669394):

> risk with this is a use case with two folders named: 01.atoms and 02.atoms.
The object keys can't have the same name. We could use a revision number for each component, but I can't evaluate the side effect of this change.

This is not an intended use of structure. In such case, we show a warning about name conflict but users should either do: 
- Use separate branches for versioning
- Using clear distinct prefix like `BaseV1/`
- I want to only keep old version, use nuxtignore patterns like `-Base/`

Using numbers is also not valid for both Javascript/ESM identifiers and [HTML tags](https://www.w3.org/TR/REC-html40/types.html#type-cdata)
