### PR TITLE
feat: allow components to provide absolute import path

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface Component {
   filePath: string
   shortPath: string
   isAsync?: boolean
+  isAbsolute?: boolean
   chunkName: string
   /** @deprecated */
   global: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface Component {
   filePath: string
   shortPath: string
   isAsync?: boolean
-  isAbsolute?: boolean
+  resolvePath?: boolean
   chunkName: string
   /** @deprecated */
   global: boolean

--- a/templates/components/index.js
+++ b/templates/components/index.js
@@ -4,13 +4,14 @@
     c.prefetch === true || typeof c.prefetch === 'number' ? `webpackPrefetch: ${c.prefetch}` : false,
     c.preload === true || typeof c.preload === 'number' ? `webpackPreload: ${c.preload}` : false,
   ].filter(Boolean).join(', ')
+  const filePath = c.isAbsolute ? c.filePath : `../${relativeToBuild(c.filePath)}`
   if (c.isAsync === true || (!isDev /* prod fallback */ && c.isAsync === null)) {
     const exp = c.export === 'default' ? `c.default || c` : `c['${c.export}']`
-    const asyncImport = `() => import('../${relativeToBuild(c.filePath)}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`
+    const asyncImport = `() => import('${filePath}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`
     return `export const ${c.pascalName} = ${asyncImport}`
   } else {
     const exp = c.export === 'default' ? `default as ${c.pascalName}` : c.pascalName
-    return `export { ${exp} } from '../${relativeToBuild(c.filePath)}'`
+    return `export { ${exp} } from '${filePath}'`
   }
 }).join('\n') %>
 

--- a/templates/components/index.js
+++ b/templates/components/index.js
@@ -4,7 +4,9 @@
     c.prefetch === true || typeof c.prefetch === 'number' ? `webpackPrefetch: ${c.prefetch}` : false,
     c.preload === true || typeof c.preload === 'number' ? `webpackPreload: ${c.preload}` : false,
   ].filter(Boolean).join(', ')
-  const filePath = c.isAbsolute ? c.filePath : `../${relativeToBuild(c.filePath)}`
+  const filePath = (c.resolvePath === false || ['~', '@'].includes(c.filePath[0]))
+    ? c.filePath 
+    : `../${relativeToBuild(c.filePath)}`
   if (c.isAsync === true || (!isDev /* prod fallback */ && c.isAsync === null)) {
     const exp = c.export === 'default' ? `c.default || c` : `c['${c.export}']`
     const asyncImport = `() => import('${filePath}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`


### PR DESCRIPTION
This would allow libraries to provide absolute import paths (from library submodules, or virtual modules) using the `components:extend` hook. In my case, I am integrating with `unplugin-icons`.