### PR TITLE
fix: webpack magic comments

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -81,16 +81,23 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
         export: 'default',
         global: Boolean(global),
         level: Number(level),
-        prefetch: Boolean(prefetch),
-        preload: Boolean(preload)
+        prefetch,
+        preload
       }
 
       if (typeof extendComponent === 'function') {
         component = (await extendComponent(component)) || component
       }
 
+      const magicComments = [
+        `webpackChunkName: "${component.chunkName}"`,
+        component.prefetch === true || typeof component.prefetch === 'number' ? `webpackPrefetch: ${component.prefetch}` : false,
+        component.preload === true || typeof component.preload === 'number' ? `webpackPreload: ${component.preload}` : false
+      ].filter(Boolean).join(', ')
+
       component.import = component.import || `require('${component.filePath}').${component.export}`
-      component.asyncImport = component.asyncImport || `function () { return import('${component.filePath}' /* webpackChunkName: "${component.chunkName}" */).then(function(m) { return m['${component.export}'] || m }) }`
+      component.asyncImport = component.asyncImport || `function () { return import('${component.filePath}' /* ${magicComments} */).then(function(m) { return m['${component.export}'] || m }) }`
+      component.magicComments = magicComments
 
       // Check if component is already defined, used to overwite if level is inferiour
       const definedComponent = components.find(c => c.pascalName === component.pascalName)

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -89,15 +89,15 @@ export async function scanComponents (dirs: ScanDir[], srcDir: string): Promise<
         component = (await extendComponent(component)) || component
       }
 
-      const magicComments = [
+      const magicComment = [
         `webpackChunkName: "${component.chunkName}"`,
         component.prefetch === true || typeof component.prefetch === 'number' ? `webpackPrefetch: ${component.prefetch}` : false,
         component.preload === true || typeof component.preload === 'number' ? `webpackPreload: ${component.preload}` : false
       ].filter(Boolean).join(', ')
 
       component.import = component.import || `require('${component.filePath}').${component.export}`
-      component.asyncImport = component.asyncImport || `function () { return import('${component.filePath}' /* ${magicComments} */).then(function(m) { return m['${component.export}'] || m }) }`
-      component.magicComments = magicComments
+      component.asyncImport = component.asyncImport || `function () { return import('${component.filePath}' /* ${magicComment} */).then(function(m) { return m['${component.export}'] || m }) }`
+      component.magicComment = magicComment
 
       // Check if component is already defined, used to overwite if level is inferiour
       const definedComponent = components.find(c => c.pascalName === component.pascalName)

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface Component {
   level: number
   prefetch: boolean | number
   preload: boolean | number
-  magicComments: string
+  magicComment: string
 }
 
 export interface ScanDir {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,9 @@ export interface Component {
   /** @deprecated */
   global: boolean
   level: number
-  prefetch: boolean
-  preload: boolean
+  prefetch: boolean | number
+  preload: boolean | number
+  magicComments: string
 }
 
 export interface ScanDir {
@@ -25,8 +26,8 @@ export interface ScanDir {
   global?: boolean | 'dev'
   pathPrefix?: boolean
   level?: number
-  prefetch?: boolean
-  preload?: boolean
+  prefetch?: boolean | number
+  preload?: boolean | number
   extendComponent?: (component: Component) => Promise<Component | void> | (Component | void)
 }
 

--- a/templates/components/index.js
+++ b/templates/components/index.js
@@ -1,7 +1,7 @@
 <%= options.getComponents().map(c => {
   if (c.isAsync === true || (!isDev /* prod fallback */ && c.isAsync === null)) {
     const exp = c.export === 'default' ? `c.default || c` : `c['${c.export}']`
-    const asyncImport = `() => import('../${relativeToBuild(c.filePath)}' /* ${c.magicComments} */).then(c => wrapFunctional(${exp}))`
+    const asyncImport = `() => import('../${relativeToBuild(c.filePath)}' /* ${c.magicComment} */).then(c => wrapFunctional(${exp}))`
     return `export const ${c.pascalName} = ${asyncImport}`
   } else {
     const exp = c.export === 'default' ? `default as ${c.pascalName}` : c.pascalName

--- a/templates/components/index.js
+++ b/templates/components/index.js
@@ -1,12 +1,7 @@
 <%= options.getComponents().map(c => {
-  const magicComments = [
-    `webpackChunkName: "${c.chunkName}"`,
-    c.prefetch === true || typeof c.prefetch === 'number' ? `webpackPrefetch: ${c.prefetch}` : false,
-    c.preload === true || typeof c.preload === 'number' ? `webpackPreload: ${c.preload}` : false,
-  ].filter(Boolean).join(', ')
   if (c.isAsync === true || (!isDev /* prod fallback */ && c.isAsync === null)) {
     const exp = c.export === 'default' ? `c.default || c` : `c['${c.export}']`
-    const asyncImport = `() => import('../${relativeToBuild(c.filePath)}' /* ${magicComments} */).then(c => wrapFunctional(${exp}))`
+    const asyncImport = `() => import('../${relativeToBuild(c.filePath)}' /* ${c.magicComments} */).then(c => wrapFunctional(${exp}))`
     return `export const ${c.pascalName} = ${asyncImport}`
   } else {
     const exp = c.export === 'default' ? `default as ${c.pascalName}` : c.pascalName


### PR DESCRIPTION
This PR fixes #197 as the following:

**Fix types**

#197 forcefully converts `prefetch` and `preload` options to boolean while I implemented a ternary logic to handle the case where they are numbers, according to Webpack's magic comment syntax.

**Add missing logic**

#197 didn't modify `component.asyncImport` string that is used to generate the source code in `loader.ts`.
Rather, it just modified magic comments in `templates/components/index.js` (and `plugin.js` at that time), which is for local development.

To avoid recalculation, I added it to Component type that a new property `magicComment`, which is a string.

Let me request review from @pi0 and @clarkdo, same as #197.